### PR TITLE
Windows SSH instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,9 +21,8 @@ When the instance is green and "started", log in to the machine:
 
 *Note: Replace `XXX.amazonaws.com` with the hostname or address of your instance*
 
-*Note: SSH isn't built into Windows, [follow the guide](WINDOWS-SSH.md)*
+*Note: SSH isn't built into Windows, <a href="WINDOWS-SSH.md" id="softwareinstall" name="softwareinstall">follow the guide</a>*
 
-<div id="softwareinstall"></div>
 ## Install software
 
     sudo apt-get update

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ When the instance is green and "started", log in to the machine:
 
 *Note: Replace `XXX.amazonaws.com` with the hostname or address of your instance*
 
+*Note: SSH isn't built into Windows, [follow the guide](WINDOWS-SSH.md)*
 
 ## Install software
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ When the instance is green and "started", log in to the machine:
 
 *Note: Replace `XXX.amazonaws.com` with the hostname or address of your instance*
 
-*Note: SSH isn't built into Windows, <a href="WINDOWS-SSH.md" id="softwareinstall" name="softwareinstall">follow the guide</a>*
+*Note: SSH isn't built into Windows, <a href="WINDOWS-SSH.md" name="installsoftware">follow the guide</a>*
 
 ## Install software
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ When the instance is green and "started", log in to the machine:
 
 *Note: SSH isn't built into Windows, [follow the guide](WINDOWS-SSH.md)*
 
-## Install software
+<h2 id="installsoftware">Install software</h2>
 
     sudo apt-get update
     sudo apt-get install nginx git-core daemon

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,8 @@ When the instance is green and "started", log in to the machine:
 
 *Note: SSH isn't built into Windows, [follow the guide](WINDOWS-SSH.md)*
 
-<h2 id="installsoftware">Install software</h2>
+<div id="softwareinstall"></div>
+## Install software
 
     sudo apt-get update
     sudo apt-get install nginx git-core daemon

--- a/WINDOWS-SSH.md
+++ b/WINDOWS-SSH.md
@@ -1,0 +1,17 @@
+# SSH in Windows
+
+Windows doesn't have SSH built in like Linux or OSX. In order to SSH to an EC2 instance under Windows there are a few more steps involved.
+
+## puTTY
+
+There are two programs required to do SSH in Windows, puTTYgen and puTTY. These can both be obtained from the puTTY [download page](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html).
+
+Since putty requires a `.ppk` file rather than `.pem` file (they're essentially the same just a different extension to store the `.pem` data) for private key authentication. Fire up `puTTYgen.exe` and load the .pem file you just. `Select file > load private key`. Change the file type filter to all files (*.*), select your `.pem` file and will bring up a dialog that you have successfully imported a foreign key. `Select file > save private key`.
+
+We know have our private key in the right format (`.ppk`). Close puTTYgen and and open puTTY.
+
+Under sessions enter your public DNS of your instance you just created, prefix the address with ubuntu@ so it will automatically use that as your username to login. Make sure port is 22 and SSH is selected in connection type.
+
+In the same window go to `Connection > SSH > Auth`. Click browse for Private key file for authentication file input and select your newly generated `.ppk` file.
+
+To avoid repeating these steps you can save your session details for easier connecting. Jump back to `Sessions` and enter a name under `Saved Sessions` and click `Save`. Now all you do is double click you saved session to connect.

--- a/WINDOWS-SSH.md
+++ b/WINDOWS-SSH.md
@@ -15,3 +15,5 @@ Under sessions enter your public DNS of your instance you just created, prefix t
 In the same window go to `Connection > SSH > Auth`. Click browse for Private key file for authentication file input and select your newly generated `.ppk` file.
 
 To avoid repeating these steps you can save your session details for easier connecting. Jump back to `Sessions` and enter a name under `Saved Sessions` and click `Save`. Now all you do is double click you saved session to connect.
+
+Head back to the [install instructions](INSTALL.md#installsoftware) to continue your setup.


### PR DESCRIPTION
INSTALL.md has a link to WINDOWS-SSH.md and vice versa so the install flow isn't too disrupted.

I was thinking of maybe adding screen grabs of the process if the instructions aren't clear enough.

Let me know what you think.
